### PR TITLE
fix: include cmake as a build dependency (pyproject.toml)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools", "cmake"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Fixes #30 

`pip install hygese` fails at build time in some systems because of missing the Python package *cmake*. This PR includes this package as a build dependency.