### PR TITLE
Add Linux aarch64 wheel

### DIFF
--- a/.github/workflows/buildpublish.yml
+++ b/.github/workflows/buildpublish.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13, macos-14]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-15-intel, macos-14]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/buildpublish.yml
+++ b/.github/workflows/buildpublish.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13, macos-14]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

Adds `ubuntu-24.04-arm` to the cibuildwheel matrix in `buildpublish.yml` so users on Linux aarch64 (AWS Graviton, Raspberry Pi 64-bit, NVIDIA Jetson, Ampere) get a prebuilt wheel instead of falling back to an sdist source build with `gcc`/`cmake`.

Uses GitHub's free public arm64 Linux runner (no QEMU) so build time is comparable to the existing x86_64 leg. cibuildwheel + `manylinux_2_34` work the same way on aarch64.

## Test plan

- [ ] `workflow_dispatch` `buildpublish.yml` on this branch — all 5 wheel jobs green (ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13, macos-14).
- [ ] Spot-install the aarch64 wheel on a Graviton box or aarch64 container; `pytest --pyargs hygese.tests` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)